### PR TITLE
Enable automatic voice listening

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Voice-Website
-A website controled using voice commands.
+A website controlled using voice commands. The page loads the microphone
+automatically and listens for a command such as **Home**, **About**, **Blog**,
+**Info**, **Fun**, **Games** or **Speach**. The highest confidence prediction is
+used to switch between sections.

--- a/index.html
+++ b/index.html
@@ -12,8 +12,7 @@
 </head>
 <body>
 <h1>Voice Controlled Website</h1>
-<p>Click "Start Listening" and speak one of the commands to navigate: Home, About, Blog, Info, Fun, Games, Speach.</p>
-<button id="listenButton" onclick="toggleListening()">Start Listening</button>
+<p>Speak a command to navigate: Home, About, Blog, Info, Fun, Games, Speach.</p>
 <div id="status"></div>
 <nav>
   <a onclick="showSection('home')">Home</a>
@@ -40,12 +39,9 @@ async function init(){
   recognizer = speechCommands.create('BROWSER_FFT', undefined, URL + 'model.json', URL + 'metadata.json');
   await recognizer.ensureModelLoaded();
 }
-async function toggleListening(){
+async function startListening(){
   if(!recognizer){ await init(); }
-  if(recognizer.isListening()){
-    recognizer.stopListening();
-    document.getElementById('listenButton').textContent = 'Start Listening';
-  } else {
+  if(!recognizer.isListening()){
     recognizer.listen(result => {
       const scores = result.scores;
       const labels = recognizer.wordLabels();
@@ -53,14 +49,14 @@ async function toggleListening(){
       for(let i=0;i<scores.length;i++){
         if(scores[i] > top.score){ top = {label: labels[i], score: scores[i]}; }
       }
-      if(top.score > 0.75){
+      if(top.label && top.label !== 'Background Noise'){
         document.getElementById('status').textContent = 'Command: ' + top.label;
         showSection(top.label.toLowerCase());
       }
-    }, {probabilityThreshold: 0.75});
-    document.getElementById('listenButton').textContent = 'Stop Listening';
+    }, {probabilityThreshold: 0});
   }
 }
+window.addEventListener('load', startListening);
 function showSection(id){
   document.querySelectorAll('section').forEach(s => {
     s.classList.toggle('active', s.id === id);


### PR DESCRIPTION
## Summary
- start listening for speech automatically when the page loads
- show the highest‑scoring prediction even if confidence is low
- document how the voice control now works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845c48b9f10832697e9db74b5cc3412